### PR TITLE
Suppress reject from preload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ export default function universal<Props: Props>(
     _mounted: boolean
 
     static preload() {
-      requireAsync()
+      requireAsync().catch(() => {})
     }
 
     constructor(props: Props) {


### PR DESCRIPTION
Sometimes, then loading failed due to any reason in preloading only - you will get UnhandledPromiseRejectionWarning.
This PR solves this problem - .preload must be absolutely silent command.