### PR TITLE
Fixes an exception thrown when using static preload function on server side

### DIFF
--- a/__test-helpers__/index.js
+++ b/__test-helpers__/index.js
@@ -78,3 +78,11 @@ export const createDynamicBablePluginComponent = (
     file: `${page}.js`
   })
 }
+
+export const dynamicBabelNodeComponent = ({ page }) => ({
+  chunkName: () => page,
+  path: () => createPath(page),
+  resolve: () => createPath(page),
+  id: page,
+  file: `${page}.js`
+})

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -24,7 +24,8 @@ import {
   createComponent,
   createDynamicComponent,
   createBablePluginComponent,
-  createDynamicBablePluginComponent
+  createDynamicBablePluginComponent,
+  dynamicBabelNodeComponent
 } from '../__test-helpers__'
 
 describe('async lifecycle', () => {
@@ -590,6 +591,20 @@ describe('advanced', () => {
 
     const component2 = renderer.create(<Component />)
     expect(component2.toJSON()).toMatchSnapshot() // success
+  })
+
+  it('Component.preload: static preload method on node', async () => {
+    const onLoad = jest.fn()
+    const onErr = jest.fn()
+    const opts = { testBabelPlugin: true }
+
+    const Component = universal(dynamicBabelNodeComponent, opts)
+    await Component.preload({ page: 'component' }).then(onLoad, onErr)
+
+    expect(onErr).not.toHaveBeenCalled()
+
+    const targetComponent = require(createPath('component')).default
+    expect(onLoad).toBeCalledWith(targetComponent)
   })
 
   it('promise passed directly', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,6 @@ export { CHUNK_NAMES, MODULE_IDS } from './requireUniversalModule'
 
 let hasBabelPlugin = false
 
-
 const isHMR = () =>
   // $FlowIgnore
   module.hot && (module.hot.data || module.hot.status() === 'apply')
@@ -48,6 +47,7 @@ export default function universal<Props: Props>(
   options.promCache = {}
 
   return class UniversalComponent extends React.Component<void, Props, *> {
+    /* eslint-disable react/sort-comp */
     _mounted: boolean
     _asyncOnly: boolean
     _component: ?Object
@@ -55,10 +55,22 @@ export default function universal<Props: Props>(
     state: State
     props: Props
     context: Object
+    /* eslint-enable react/sort-comp */
 
     static preload(props: Props, context: Object = {}) {
       props = props || {}
-      const { requireAsync } = req(component, options, props)
+      const { requireAsync, requireSync } = req(component, options, props)
+      let Component
+
+      try {
+        Component = requireSync(props, context)
+      }
+      catch (error) {
+        return Promise.reject(error)
+      }
+
+      if (Component) return Promise.resolve(Component)
+
       return requireAsync(props, context)
     }
 


### PR DESCRIPTION
This fixes issue #31

I think it would be better solved in `requireAsync` function to support 'sync' version on server side, but that change over-complicated tests and I gave up on that idea :-)

So instead, i just used the same logic as it was in the componentWillReceiveProps, to optimistically try and fetch the component synchronously and fallback to async as it was before.