### PR TITLE
failing test for tryRequire

### DIFF
--- a/__fixtures__/bad.es6.js
+++ b/__fixtures__/bad.es6.js
@@ -1,0 +1,3 @@
+export default (() => {
+  throw new Error('badModule')
+})()

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -16,13 +16,20 @@ test('tryRequire: requires module using key export finder + calls onLoad with mo
   expect(mod).toEqual(expectedModule)
 
   // webpack
-  global.__webpack_require__ = path => __webpack_modules__[path]
+  global.__webpack_require__ = path => __webpack_modules__[path]()
   global.__webpack_modules__ = {
-    [moduleEs6]: expectedModule
+    [moduleEs6]: () => expectedModule
   }
 
   mod = tryRequire(moduleEs6)
   expect(mod).toEqual(expectedModule)
+
+  // Bad Modules
+  const badEs6 = createPath('bad.es6')
+  global.__webpack_modules__ = {
+    [badEs6]: () => require(badEs6)
+  }
+  expect(() => tryRequire(badEs6)).toThrow()
 
   delete global.__webpack_require__
   delete global.__webpack_modules__


### PR DESCRIPTION
currently `tryRequire` fails silently assuming the cause is the module is not loaded by webpack. but there is a case where the module exists but throws an error while being imported. it might be better to check if the error is `ModuleNotFoundError` or throw it.