### PR TITLE
Another improvement to TS type checking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ declare module 'react-universal-component' {
      * It can be a string corresponding to the export key, or a function that's
      * passed the entire module and returns the export that will become the component.
      */
-    key: string | ((module: Export) => ComponentType<P>);
+    key: keyof Export | ((module: Export) => ComponentType<P>);
 
     /**
      * Allows you to specify a maximum amount of time before the error component


### PR DESCRIPTION
```typescript
export const LoadableNotablePerson = universal(import('./NotablePerson'), {
  key: 'NotablePerson',
});
```

If key is a string, it must be a key of the export module object. This helps avoid typos.