### PR TITLE
refactor: Log error stacktrace in tryRequire

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,10 @@ export const tryRequire = (id: Id): ?any => {
     // warn if there was an error while requiring the chunk during development
     // this can sometimes lead the server to render the loading component.
     if (process.env.NODE_ENV === 'development') {
-      console.warn(`chunk not available for synchronous require yet: ${id}: ${err.message}`)
+      console.warn(
+        `chunk not available for synchronous require yet: ${id}: ${err.message}`,
+        err.stack
+      )
     }
   }
 


### PR DESCRIPTION
tryRequire was only logging the module id and error message when an error occured. Logging the
stacktrace as well improves the debug experience.

#86