### PR TITLE
Improve loading & error typescript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,14 +141,14 @@ declare module 'react-universal-component' {
      * that displays while the primary import is loading.
      * While testing out this package, you can leave it out as a simple default one is used.
      */
-    loading(p: P): JSX.Element | ComponentType<P>;
+    loading: ((p: P) => JSX.Element | ComponentType<P>) | (JSX.Element | ComponentType<P>);
 
     /**
      * The component that displays if there are any errors that occur during
      * your aynschronous import. While testing out this package,
      * you can leave it out as a simple default one is used.
      */
-    error(p: P): JSX.Element | ComponentType<P & { error: Error }>;
+    error: ((p: P) => JSX.Element | ComponentType<P & { error: Error }>) | (JSX.Element | ComponentType<P & { error: Error }>);
   }>;
 
   export default function universal<


### PR DESCRIPTION
I have improved the typescript declaration for `error` and `loading` options to better match the documentation.

Previously the following would not work:

```tsx
const LoadingComponent = () => <div>Loading</div>;
const ErrorComponent = () => <div>Error</div>;

const UniversalFoo = universal(() => import('./Foo'), {
  loading: LoadingComponent, // ts error
  error: ErrorComponent, // ts error
});
const UniversalBar = universal(() => import('./Bar'), {
  loading: <LoadingComponent />, // ts error
  error: <ErrorComponent />, // ts error
});
```

Now all the available ways to pass `loading` and `error` will work properly:

e.g.

```tsx
() => <LoadingComponent />
() => LoadingComponent
<LoadingComponent />
LoadingComponent
```