### PR TITLE
Hoist non-react-statics on preload

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -594,6 +594,25 @@ describe('advanced', () => {
     expect(component2.toJSON()).toMatchSnapshot() // success
   })
 
+  it('Component.preload: static preload method hoists non-react statics', async () => {
+    // define a simple component with static properties
+    const FooComponent = props => (
+      <div>FooComponent {JSON.stringify(props)}</div>
+    )
+    FooComponent.propTypes = {}
+    FooComponent.nonReactStatic = { foo: 'bar' }
+    // prepare that component to be universally loaded
+    const components = { FooComponent }
+    const asyncComponent = createDynamicComponent(40, components)
+    const Component = universal(asyncComponent)
+    // wait for preload to finish
+    await Component.preload({ page: 'FooComponent' })
+    // assert desired static is available
+    expect(Component).not.toHaveProperty('propTypes')
+    expect(Component).toHaveProperty('nonReactStatic')
+    expect(Component.nonReactStatic).toBe(FooComponent.nonReactStatic)
+  })
+
   it('Component.preload: static preload method on node', async () => {
     const onLoad = jest.fn()
     const onErr = jest.fn()

--- a/src/index.js
+++ b/src/index.js
@@ -70,9 +70,15 @@ export default function universal<Props: Props>(
         return Promise.reject(error)
       }
 
-      if (Component) return Promise.resolve(Component)
-
-      return requireAsync(props, context)
+      return Promise.resolve()
+        .then(() => {
+          if (Component) return Component
+          return requireAsync(props, context)
+        })
+        .then(Component => {
+          hoist(UniversalComponent, Component, { preload: true })
+          return Component
+        })
     }
 
     static contextTypes = {


### PR DESCRIPTION
currently hoisting on non-react-statics only happens in `onAfter`. based on the example in readme, 
```js
const MyUniversalComponent = universal(import('./MyComponent'))

// render it
<MyUniversalComponent />

// call this only after you're sure it has loaded
MyUniversalComponent.doSomething()
```
I was expecting that I would have `doSomething` available after calling `preload()`, like
```js
const MyUniversalComponent = universal(import('./MyComponent'))

// preload it
MyUniversalComponent.preload()
  .then(() => {
    // I am sure that it has loaded at this point
    MyUniversalComponent.doSomething()
  });
```

This PR adds that `hoist` call at the end of `preload`, and it also adds a test case for that functionality