### PR TITLE
Added preloadWeak static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,18 @@ const MyUniversalComponent = universal(import('./MyComponent'))
 
 // call this only after you're sure it has loaded
 MyUniversalComponent.doSomething()
+
+// If you are not sure if the component has loaded or rendered, call preloadWeak().
+// This will attempt to hoist and return the inner component,
+// but only if it can be loaded synchronously, otherwise null will be returned.
+const InnerComponent = MyUniversalComponent.preloadWeak()
+if (InnerComponent) {
+    InnerComponent.doSomething()
+}
 ```
 > NOTE: for imports using dynamic expressions, conflicting methods will be overwritten by the current component
+
+> NOTE: preloadWeak() will not cause network requests, which means that if the component has not loaded, it will return null. Use it only when you need to retrieve and hoist the wrapped component before rendering. Calling preloadWeak() on your server will ensure that all statics are hoisted properly.
 
 ## Props API
 

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,10 @@ export default function universal<Props: Props>(
           return requireAsync(props, context)
         })
         .then(Component => {
-          hoist(UniversalComponent, Component, { preload: true, preloadWeak: true })
+          hoist(UniversalComponent, Component, {
+            preload: true,
+            preloadWeak: true
+          })
           return Component
         })
     }
@@ -87,7 +90,10 @@ export default function universal<Props: Props>(
 
       const Component = requireSync(props, context)
       if (Component) {
-          hoist(UniversalComponent, Component, { preload: true, preloadWeak: true })
+        hoist(UniversalComponent, Component, {
+          preload: true,
+          preloadWeak: true
+        })
       }
 
       return Component
@@ -240,7 +246,10 @@ export default function universal<Props: Props>(
       const { Component, error } = state
 
       if (Component && !error) {
-        hoist(UniversalComponent, Component, { preload: true, preloadWeak: true })
+        hoist(UniversalComponent, Component, {
+          preload: true,
+          preloadWeak: true
+        })
 
         if (this.props.onAfter) {
           const { onAfter } = this.props

--- a/src/index.js
+++ b/src/index.js
@@ -76,9 +76,21 @@ export default function universal<Props: Props>(
           return requireAsync(props, context)
         })
         .then(Component => {
-          hoist(UniversalComponent, Component, { preload: true })
+          hoist(UniversalComponent, Component, { preload: true, preloadWeak: true })
           return Component
         })
+    }
+
+    static preloadWeak(props: Props, context: Object = {}) {
+      props = props || {}
+      const { requireSync } = req(component, options, props)
+
+      const Component = requireSync(props, context)
+      if (Component) {
+          hoist(UniversalComponent, Component, { preload: true, preloadWeak: true })
+      }
+
+      return Component
     }
 
     static contextTypes = {
@@ -228,7 +240,7 @@ export default function universal<Props: Props>(
       const { Component, error } = state
 
       if (Component && !error) {
-        hoist(UniversalComponent, Component, { preload: true })
+        hoist(UniversalComponent, Component, { preload: true, preloadWeak: true })
 
         if (this.props.onAfter) {
           const { onAfter } = this.props


### PR DESCRIPTION
Added preloadWeak which attempts to resolve and hoist the wrapped component synchronously. This is useful when reading or writing data from/to static properties before initial render.

I'm not sure if this implementation is correct, but I think with the description given in #119 you can understand what the desired behavior is.
Thanks.

PS The name or method of invoking this doesn't matter, you can add an optional parameter to preload or add a preload.sync or whatever.