### PR TITLE
feat(requireUniversalModule.js): Always apply options & allow skipping of babelRename

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The first argument can be a function that returns a promise, a promise itself, o
 - `minDelay`: `0` -- *default*
 - `alwaysDelay`: `false` -- *default*
 - `loadingTransition`: `true` -- *default*
+- `ignoreBabelRename`: `false` -- *default*
 
 
 **In Depth:**
@@ -190,6 +191,7 @@ onLoad: (module, info, props, context) => {
 - `alwaysDelay` is a boolean you can set to true (*default: false*) to guarantee the `minDelay` is always used (i.e. even when components cached from previous imports and therefore synchronously and instantly required). This can be useful for guaranteeing animations operate as you want without having to wire up other components to perform the task. *Note: this only applies to the client when your `UniversalComponent` uses dynamic expressions to switch between multiple components.*
 
 - `loadingTransition` when set to `false` allows you to keep showing the current component when the `loading` component would otherwise show during transitions from one component to the next.
+- `ignoreBabelRename` is by default set to `false` which allows the plugin to attempt and name the dynamically imported chunk (replacing `/` with `-`).  In more advanced scenarios where more granular control is required over the webpack chunk name, you should set this to `true` in addition to providing a function to `chunkName` to control chunk naming.
 
 ## What makes Universal Rendering so painful
 

--- a/src/flowTypes.js
+++ b/src/flowTypes.js
@@ -38,7 +38,8 @@ export type ModuleOptions = {
   modCache: Object,
   promCache: Object,
   id?: string,
-  usesBabelPlugin?: boolean
+  usesBabelPlugin?: boolean,
+  ignoreBabelRename?: boolean
 }
 
 export type ComponentOptions = {

--- a/src/requireUniversalModule.js
+++ b/src/requireUniversalModule.js
@@ -139,7 +139,11 @@ export default function requireUniversalModule<Props: Props>(
       if (chunkName) {
         let name = callForString(chunkName, props)
         if (usesBabelPlugin) {
-          name = name.replace(/\//g, '-')
+          // if ignoreBabelRename is true, don't apply regex
+          const shouldKeepName = options && !!options.ignoreBabelRename
+          if (!shouldKeepName) {
+            name = name.replace(/\//g, '-')
+          }
         }
         if (name) CHUNK_NAMES.add(name)
         if (!isTest) return name // makes tests way smaller to run both kinds
@@ -201,9 +205,14 @@ const getConfig = (
   props: Props
 ): Config => {
   if (isDynamic) {
-    return typeof universalConfig === 'function'
-      ? universalConfig(props)
-      : universalConfig
+    let resultingConfig =
+      typeof universalConfig === 'function'
+        ? universalConfig(props)
+        : universalConfig
+    if (options) {
+      resultingConfig = { ...resultingConfig, ...options }
+    }
+    return resultingConfig
   }
 
   const load: Load =


### PR DESCRIPTION
In addModule method, we will now use the 'ignoreBabelRename' to determine if we should skip applying
a regex to the chunk name which is typically determined from the file path (with `/` replaced with `-` characters).  This is not always the case, as dynamic imports can have static strings, and can also reference webpack aliases. This gives the user more control over what they want. Additionally, in the getConfig method, options provided, (e.g. a custom chunkName function), does not get used.