### PR TITLE
Fixed Typescript definitions for `react-universal-component/server`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,10 +198,3 @@ declare module 'react-universal-component' {
     options?: Options<P, C, Export>
   ): UniversalComponent<P>;
 }
-
-declare module 'react-universal-component/server' {
-  const clearChunks: () => void;
-  const flushChunkNames: () => string[];
-
-  export { clearChunks, flushChunkNames };
-}

--- a/server.d.ts
+++ b/server.d.ts
@@ -1,0 +1,6 @@
+declare module 'react-universal-component/server' {
+  const clearChunks: () => void;
+  const flushChunkNames: () => string[];
+
+  export { clearChunks, flushChunkNames };
+}


### PR DESCRIPTION
When using `import { ... } from 'react-universal-component/server` in a Typescript app with `--noImplicitAny` enabled, it complains that it can't find type definitions for `react-universal-component/server`. I'm fairly new to Typescript, but according to https://github.com/Microsoft/TypeScript/issues/8305, TS is finicky when it comes to definition file look-ups. The compiler will fail rather than finding the definition in `index.d.ts`. This is assuming `react-universal-component` hasn't been imported previously (so the compiler isn't aware of `index.d.ts` yet.)

The simplest solution I found is to pull out the `react-universal-component/server` definitions into their own file alongside `server.js`. Fixes the problem without having to manually define the definition path in my `tsconfig.json`.