### PR TITLE
fix(utils): Fixing Critical dependencies warnings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -50,10 +50,10 @@ export const tryRequire = (id: Id): ?any => {
 
 export const requireById = (id: Id): ?any => {
   if (!isWebpack() && typeof id === 'string') {
-    return module.require(id)
+    return module.require(`${id}`)
   }
 
-  return __webpack_require__(id)
+  return __webpack_require__(`${id}`)
 }
 
 export const resolveExport = (


### PR DESCRIPTION
Webpack complains when using a variable, so we give it a string

Fixes #139 