### PR TITLE
fix: Isolate require function 

### DIFF
--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,11 +1,8 @@
 import { createPath } from '../__test-helpers__'
 
-import {
-  tryRequire,
-  requireById,
-  resolveExport,
-  findExport
-} from '../src/utils'
+import { tryRequire, resolveExport, findExport } from '../src/utils'
+
+import requireById from '../src/requireById'
 
 test('tryRequire: requires module using key export finder + calls onLoad with module', () => {
   const moduleEs6 = createPath('es6')

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "build": "babel src -d dist",
-    "flow-copy": "flow-copy-source src dist",
+    "flow-copy": "flow-copy-source src dist -i 'requireById/index.js'",
     "flow-watch": "clear; printf \"\\033[3J\" & npm run flow & fswatch -o ./ | xargs -n1 -I{} sh -c 'clear; printf \"\\033[3J\" && npm run flow'",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "clean": "rimraf dist && mkdir dist",

--- a/src/requireById/index.js
+++ b/src/requireById/index.js
@@ -1,0 +1,11 @@
+import { isWebpack } from '../utils'
+
+const requireById = id => {
+  if (!isWebpack() && typeof id === 'string') {
+    return module.require(`${id}`)
+  }
+
+  return __webpack_require__(`${id}`)
+}
+
+export default requireById

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import requireById from './requireById'
 
 import type {
   Id,
@@ -46,14 +47,6 @@ export const tryRequire = (id: Id): ?any => {
   }
 
   return null
-}
-
-export const requireById = (id: Id): ?any => {
-  if (!isWebpack() && typeof id === 'string') {
-    return module.require(`${id}`)
-  }
-
-  return __webpack_require__(`${id}`)
 }
 
 export const resolveExport = (


### PR DESCRIPTION
Moving requrieById into an isolated folder which will allow for string usage without importing anything else inside RUC, like flow types

Fix #139 #151 