### PR TITLE
Update the UniversalComponent.preload TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare module 'react-universal-component' {
   type UniversalComponent<P> = React.StatelessComponent<
     P & Partial<UniversalProps>
   > & {
-    preload(options?: P): void;
+    preload(props?: P): void;
   };
 
   type Module<P> =

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare module 'react-universal-component' {
   type UniversalComponent<P> = React.StatelessComponent<
     P & Partial<UniversalProps>
   > & {
-    preload(): void;
+    preload(options?: P): void;
   };
 
   type Module<P> =


### PR DESCRIPTION
The TypeScript definition for the `UniversalComponent.preload` static function does not accept props as defined, but the underlying function _does_ allow a user to pass props (thus achieving something like the example's ability to pass a dynamic `page` prop into the `load` function).

This fixes that.

Big, important stuff, I know.