### PR TITLE
fix(src/index.js): Re #186: onAfter called after preload in V3 but no…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -240,9 +240,8 @@ export default function universal<Props: Props>(
 
     constructor(props: Props, context: {}) {
       super(props, context)
-      this.state = this.init(this.props, this.context)
       // $FlowFixMe
-      this.state.error = null
+      this.state = { error: null }
     }
 
     static getDerivedStateFromProps(nextProps, currentState) {
@@ -261,6 +260,7 @@ export default function universal<Props: Props>(
 
     componentDidMount() {
       this._initialized = true
+      this.state = this.init(this.props, this.context)
     }
 
     componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
…t V4

Move init() call from constructor to componentDidMount, after _initialize is set to true, so that
__update() fires __handleAfter on first run

fix #186